### PR TITLE
Update gnome-desktop and totem-pl-parser

### DIFF
--- a/org.gnome.Cheese.yml
+++ b/org.gnome.Cheese.yml
@@ -32,8 +32,8 @@ modules:
       - -Dudev=disabled
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gnome-desktop/3.34/gnome-desktop-3.34.2.tar.xz
-        sha256: 4081ba619733da33ec6ba98cd52170ee99a90439709df4df333e5c9e631f28ed
+        url: https://download.gnome.org/sources/gnome-desktop/3.34/gnome-desktop-3.34.4.tar.xz
+        sha256: c53e72737cc21535f2fd4b72bc2fb5594741cfc3d3ce90949bc5cc07bade0cbc
   - shared-modules/lua5.3/lua-5.3.5.json
   - name: libquvi-scripts
     sources:
@@ -49,8 +49,8 @@ modules:
     buildsystem: meson
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/totem-pl-parser/3.26/totem-pl-parser-3.26.4.tar.xz
-        sha256: c1576f551a67c2b3632a3dbea5d8b3e9966558af0cfeed58f07cec04728364f0
+        url: https://download.gnome.org/sources/totem-pl-parser/3.26/totem-pl-parser-3.26.5.tar.xz
+        sha256: 5370de46f2e848221779275479b96ac39115b1efd2b0293d4afa87e22c8c528c
   - name: totem-video-thumbnailer
     buildsystem: meson
     sources:


### PR DESCRIPTION
gnome-desktop was updated to the newest point release of the 3.34
series.