### PR TITLE
Updated runtime to 42

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git
+	branch = master

--- a/org.gnome.Cheese.yml
+++ b/org.gnome.Cheese.yml
@@ -77,6 +77,8 @@ modules:
         sha256: 4dc68e9b38fdfc1e8e0414e2d7ee83ace78efdee76f30506cc9dcd07394ad0c8
 
   - shared-modules/libcanberra/libcanberra.json
+  
+  - shared-modules/clutter/clutter.json
 
   - name: cheese
     buildsystem: meson

--- a/org.gnome.Cheese.yml
+++ b/org.gnome.Cheese.yml
@@ -1,7 +1,7 @@
 id: org.gnome.Cheese
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
-runtime-version: '41'
+runtime-version: '42'
 command: cheese
 finish-args:
   - --share=ipc


### PR DESCRIPTION
Runtime 41 is now end-of-life according to flatpak:

Info: org.gnome.Platform//41 is end-of-life, with reason:
   The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
   org.gnome.Cheese

Not sure why this source was already version 42, instead:

https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.4.tar.xz