### PR TITLE
Updated runtime to 43

### DIFF
--- a/d58071c56dc46299357c46da5ef9682d8d0abfa4.patch
+++ b/d58071c56dc46299357c46da5ef9682d8d0abfa4.patch
@@ -1,0 +1,49 @@
+From d58071c56dc46299357c46da5ef9682d8d0abfa4 Mon Sep 17 00:00:00 2001
+From: Michael Catanzaro <mcatanzaro@redhat.com>
+Date: Mon, 11 Apr 2022 17:07:21 -0500
+Subject: [PATCH] thumb-view: update for new gnome-desktop API
+
+See gnome-desktop!132
+---
+ src/thumbview/cheese-thumb-view.c | 18 ++++++++++++++++++
+ 1 file changed, 18 insertions(+)
+
+diff --git a/src/thumbview/cheese-thumb-view.c b/src/thumbview/cheese-thumb-view.c
+index f01b33df..fce8687d 100644
+--- a/src/thumbview/cheese-thumb-view.c
++++ b/src/thumbview/cheese-thumb-view.c
+@@ -134,6 +134,23 @@ cheese_thumb_view_idle_append_item (gpointer data)
+ 
+   if (!thumb_loc)
+   {
++#if defined(GNOME_DESKTOP_PLATFORM_VERSION) && GNOME_DESKTOP_PLATFORM_VERSION >= 43
++    pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail (factory, uri, mime_type, NULL, &error);
++    if (!pixbuf)
++    {
++      g_warning ("could not generate thumbnail for %s (%s): %s\n", filename, mime_type, error->message);
++      g_clear_error (&error);
++    }
++    else
++    {
++      gnome_desktop_thumbnail_factory_save_thumbnail (factory, pixbuf, uri, mtime.tv_sec, NULL, &error);
++      if (error)
++      {
++        g_warning ("could not save thumbnail for %s (%s): %s\n", filename, mime_type, error->message);
++        g_clear_error (&error);
++      }
++    }
++#else
+     pixbuf = gnome_desktop_thumbnail_factory_generate_thumbnail (factory, uri, mime_type);
+     if (!pixbuf)
+     {
+@@ -143,6 +160,7 @@ cheese_thumb_view_idle_append_item (gpointer data)
+     {
+       gnome_desktop_thumbnail_factory_save_thumbnail (factory, pixbuf, uri, mtime.tv_sec);
+     }
++#endif
+   }
+   else
+   {
+-- 
+GitLab
+

--- a/org.gnome.Cheese.yml
+++ b/org.gnome.Cheese.yml
@@ -1,7 +1,7 @@
 id: org.gnome.Cheese
 runtime: org.gnome.Platform
 sdk: org.gnome.Sdk
-runtime-version: '42'
+runtime-version: '43'
 command: cheese
 finish-args:
   - --share=ipc
@@ -34,8 +34,8 @@ modules:
       - -Dudev=disabled
     sources:
       - type: archive
-        url: https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.4.tar.xz
-        sha256: 1ce2c9d5067969dbe0b282ea5a9acfb8698751f03cd07e2c730240f85dc9ad25
+        url: https://download.gnome.org/sources/gnome-desktop/43/gnome-desktop-43.tar.xz
+        sha256: 3d6e153317486157596aa3802f87676414c570738f450a94a041fe8835420a69
         x-checker-data:
           type: gnome
           name: gnome-desktop
@@ -91,3 +91,5 @@ modules:
         x-checker-data:
           type: gnome
           name: cheese
+      - type: patch
+        path: "d58071c56dc46299357c46da5ef9682d8d0abfa4.patch"


### PR DESCRIPTION
Runtime 41 is now end-of-life according to flatpak:

Info: org.gnome.Platform//41 is end-of-life, with reason:
The GNOME 41 runtime is no longer supported as of September 17, 2022. Please ask your application developer to migrate to a supported platform.
Applications using this runtime:
org.gnome.Cheese

Not sure why this source was already version 42, instead:

https://download.gnome.org/sources/gnome-desktop/42/gnome-desktop-42.4.tar.xz
