### PR TITLE
Restrict access to Pipewire socket

### DIFF
--- a/org.gnome.Cheese.yml
+++ b/org.gnome.Cheese.yml
@@ -8,8 +8,9 @@ finish-args:
   - --socket=fallback-x11
   - --socket=pulseaudio
   - --socket=wayland
-  - --device=all
+  - --device=dri
   - --metadata=X-DConf=migrate-path=/org/gnome/Cheese/
+  - --filesystem=xdg-run/pipewire-0
   - --filesystem=xdg-pictures
   - --filesystem=xdg-videos
 cleanup:


### PR DESCRIPTION
This small change does several things:
1. By disabling direct device access (dri is needed for GL rendering), Gstreamer will only find the Pipewire device provider. This is effectively the same effect as using the xdg-camera portal, just using an unrestricted Pipewire socked. The idea is that the Flatpak Cheese users are a relatively small subset of Cheese users with high chances of having a well working Pipewire setup in place, serving as a good test group. This should be fair, as Flatpak users are likely most interested in the sandboxing capabilities offered by the switch to Pipewire/xdg-portals.
2. Pipewire has backends for both V4L2 and libcamera. There are more and more modern cameras around, especially on mobile/arm devices, that need libcamera to produce a working output. By using Pipewire, there is a central place for camera configuration. So with this change, if Pipewire is configured correctly, then things also work for Cheese.
3. Right now there are a lot of devices out there with broken kernel drivers. Gstreamer currently does not always handle that well yet, breaking output for Cheese. One example that affects devices like the Pine[phone|book] Pro is that the driver offers broken V4L2 encoding. While this should be fixed in Gstreamer[1], the change here ensures that Gstreamer always uses software encoding for now, unbreaking cameras on the previously mentioned devices. The change thus prioritizes functionality over performance, while hopefully highlighting issues in the rest of the stack, such as the mentioned Gstreamer issue and missing support in Pipewire for V4L2 encoding.

In case users experience regressions, they can easily revert to the previous behavior by enabling `device=all` via e.g. Flatseal. The big advantage here is that the knowledge about any issues would be very valuable for further Pipewire/Gstreamer/Cheese development.

Overall this should make the Cheese Flatpak one of the first apps to work out of the box for users on a bunch of devices - which in turn plays perfectly into the role of Cheese as a camera test app.

1: https://gitlab.freedesktop.org/gstreamer/gstreamer/-/issues/1631

---

See also:
- https://gitlab.gnome.org/GNOME/cheese/-/issues/95